### PR TITLE
7 - Add TTC

### DIFF
--- a/agencies/ttc/ttc.js
+++ b/agencies/ttc/ttc.js
@@ -1,0 +1,48 @@
+const axios = require('axios');
+const addVehiclesToCassandra = require('../../vehicleUpdater');
+const config = require('../../config');
+const ttcConfig = require('./ttcConfig');
+
+/*
+ * TTC uses the NextBus API
+ * We use our version of Restbus, which gets all the vehicles
+ * https://github.com/trynmaps/restbus
+ * 
+ * A lot of this code is similar to the one used in Muni.js
+ * See https://github.com/trynmaps/orion/issues/8 
+ * 
+ */
+
+function updateTtcVehicles() {
+  return axios.get('/agencies/ttc/vehicles', {
+    baseURL: config.restbusURL
+  })
+    .then((response) => {
+      const vehicles = response.data;
+      console.log(vehicles);
+      return vehicles.map(makeOrionVehicleFromNextbus);
+    })
+    .then((vehicles) => {
+      return addVehiclesToCassandra(
+        vehicles,
+        ttcConfig.keyspace,
+        ttcConfig.vehicleTable,
+      );
+    })
+    .catch((error) => {
+      console.log(error);
+    });
+}
+
+function makeOrionVehicleFromNextbus(nextbusObject) {
+  const { id, routeId, lat, lon, heading } = nextbusObject;
+  return {
+    rid: routeId,
+    vid: id,
+    lat,
+    lon,
+    heading,
+  };
+}
+
+module.exports = updateTtcVehicles;

--- a/agencies/ttc/ttcConfig.json
+++ b/agencies/ttc/ttcConfig.json
@@ -1,0 +1,8 @@
+{
+  "name": "ttc",
+  "nextbusName": "ttc",
+  "keyspace": "ttc",
+  "vehicleTable": "ttc_realtime_vehicles",
+  "stopStateTable": "ttc_stop_states",
+  "model": "ttcTable.cql"
+}

--- a/agencies/ttc/ttcTable.cql
+++ b/agencies/ttc/ttcTable.cql
@@ -1,0 +1,19 @@
+-- Stores an hour of all TTC vehicle
+-- locations in 15-second intervals
+
+CREATE KEYSPACE ttc WITH REPLICATION = { 
+    'class': 'SimpleStrategy',
+    'replication_factor': 2 
+};
+
+CREATE TABLE ttc.ttc_realtime_vehicles ( 
+    vdate date,
+    vhour smallint,
+    rid ascii,
+    vid ascii,
+    vtime timestamp,
+    lat float,
+    lon float,
+    heading int,
+PRIMARY KEY ((vdate, vhour), vtime, rid, vid)
+);

--- a/index.js
+++ b/index.js
@@ -3,11 +3,12 @@ const config = require('./config');
 
 const muni = require('./agencies/muni/muni');
 const marin = require('./agencies/marin/marin');
+const ttc = require('./agencies/ttc/ttc');
 
 setInterval(updateVehicles, 15000);
 
 function updateVehicles() {
-  return Promise.all([muni, marin].map((agency) => {
+  return Promise.all([muni, marin, ttc].map((agency) => {
     return agency();
   })).catch((err) => {
     console.log(err);


### PR DESCRIPTION
This commit adds TTC support to Orion by having it
reuse the existing functions that were already
being used for Muni.

https://github.com/trynmaps/orion/issues/7

The next step is to generalize these functions into
a Nextbus module so that all agencies using nextbus
can automatically be added into OpenTransit.

TODO - https://github.com/trynmaps/orion/issues/8