### PR TITLE
Improve Cassandra connection error messages

### DIFF
--- a/cassandraHelper.js
+++ b/cassandraHelper.js
@@ -5,8 +5,11 @@ const client = new cassandra.Client({
   contactPoints: [config.cassandraURL],
 });
 client.connect((err) => {
-  console.log('connected to cassandra');
-  console.log('error:' + err);
+  if (err) {
+    console.log('error:' + err);
+  } else {
+    console.log('connected to cassandra');
+  }
 });
 
 function cassandraBatch(queries) {


### PR DESCRIPTION
This commit does the following:
1) when connection is successful, it no longer shows `error: undefined`, which is misleading.
2) when connection is not successful, it no longer shows `connected to cassandra` - just the error message