### PR TITLE
Add direction id to cassandra

### DIFF
--- a/agencies/marin/marin.js
+++ b/agencies/marin/marin.js
@@ -62,14 +62,14 @@ const headingInDegrees = {
   NW: 315,
 };
 function makeOrionVehicleFromMarin(marinObject) {
-  const { ID, RouteId, Latitude, Longitude, Heading, PatternID } = marinObject;
+  const { ID, RouteId, Latitude, Longitude, Heading, PatternId } = marinObject;
   return {
     rid: routeNames[RouteId],
     vid: String(ID),
     lat: Latitude,
     lon: Longitude,
     heading: headingInDegrees[Heading],
-    did: PatternID,
+    did: String(PatternId),
   };
 }
 

--- a/vehicleUpdater.js
+++ b/vehicleUpdater.js
@@ -6,10 +6,10 @@ function addVehiclesToCassandra(vehicles, keyspace, table) {
   const vdate = vtime.toISOString().slice(0, 10);
   const queries = vehicles
     .map(vehicle => {
-      const { rid, vid, lat, lon, heading } = vehicle;
-      return rid, vid, lat, lon, heading && {
-        query: `INSERT INTO ${keyspace}.${table} (vdate, vhour, rid, vid, vtime, lat, lon, heading) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-        params: [vdate, vhour, rid, vid, vtime, lat, lon, heading],
+      const { rid, vid, lat, lon, did, heading } = vehicle;
+      return rid, vid, lat, lon, did, heading && {
+        query: `INSERT INTO ${keyspace}.${table} (vdate, vhour, rid, vid, vtime, lat, lon, did, heading) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        params: [vdate, vhour, rid, vid, vtime, lat, lon, did, heading],
       };
     })
     .filter(vehicle => vehicle);


### PR DESCRIPTION
- Change case of Pattern id for marin data to fix insert failures.
- Coerce Pattern id to string for marin data as it is returned as numeric from api
- Add did field to insert statement for cassandra

Sample data in Cassandra after changes:

```
cqlsh> select * from muni.muni_realtime_vehicles limit 1;

 vdate      | vhour | vtime                           | rid | vid  | did        | heading | lat      | lon
------------+-------+---------------------------------+-----+------+------------+---------+----------+------------
 2018-05-21 |    20 | 2018-05-21 03:05:08.537000+0000 |   1 | 5496 | 1____O_F00 |     255 | 37.79341 | -122.40619

(1 rows)
```

```
cqlsh> select * from marin.marin_realtime_vehicles limit 1;

 vdate      | vhour | vtime                           | rid | vid  | did  | heading | lat      | lon
------------+-------+---------------------------------+-----+------+------+---------+----------+------------
 2018-05-21 |    20 | 2018-05-21 03:05:09.343000+0000 | 219 | 1128 | 1768 |     315 | 37.98862 | -122.52715

(1 rows)
```
```
cqlsh> select * from ttc.ttc_realtime_vehicles limit 1;

 vdate      | vhour | vtime                           | rid | vid  | did        | heading | lat      | lon
------------+-------+---------------------------------+-----+------+------------+---------+----------+-----------
 2018-05-21 |    20 | 2018-05-21 03:05:08.521000+0000 | 100 | 8655 | 100_0_100A |     268 | 43.71065 | -79.33167
```