### PR TITLE
35 - store leading vehicle ID

### DIFF
--- a/nextbus.js
+++ b/nextbus.js
@@ -1,6 +1,15 @@
 module.exports = {
-  makeOrionVehicleFromNextbus: function(nextbusObject) {
-    const { id, routeId, lat, lon, heading, directionId, secsSinceReport } = nextbusObject;
+  makeOrionVehicleFromNextbus: function (nextbusObject) {
+    const {
+      id,
+      routeId,
+      lat,
+      lon,
+      heading,
+      directionId,
+      secsSinceReport,
+      leadingVehicleId,
+    } = nextbusObject;
     return {
       rid: routeId,
       vid: id,
@@ -9,6 +18,7 @@ module.exports = {
       heading,
       did: directionId,
       secsSinceReport,
+      leadingVid: leadingVehicleId,
     };
   },
 }


### PR DESCRIPTION
Store `leadingVehicleId` as to remove duplicate vehicles (ie. follower vehicles in a 2+ car train) as described in https://github.com/trynmaps/tryn-api/pull/42