### PR TITLE
use kubernetes configmap to store production config

### DIFF
--- a/kubernetes/orion-deployment.yaml
+++ b/kubernetes/orion-deployment.yaml
@@ -27,26 +27,10 @@ spec:
             cpu: 0.03
         env:
           - name: ORION_CONFIG_JSON
-            value: >
-              {
-                 "s3_bucket": "orion-vehicles",
-                 "agencies": [
-                   {
-                     "id": "muni",
-                     "provider": "nextbus",
-                     "nextbus_agency_id": "sf-muni"
-                   },
-                   {
-                     "id": "ttc",
-                     "provider": "nextbus",
-                     "nextbus_agency_id": "ttc"
-                   },
-                   {
-                     "id": "marin",
-                     "provider": "marin"
-                   }
-                 ]
-              }
+            valueFrom:
+              configMapKeyRef:
+                name: orion
+                key: orion_config_json
           - name: AWS_ACCESS_KEY_ID
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
This avoids needing to check in the config to Git since it may contain semi-secret keys for provider APIs.
 
To change the agencies that are collected, the configmap for OpenTransit's current orion instance can be edited at 
https://console.cloud.google.com/kubernetes/configmap/us-central1-a/metrics-mvp-cluster/default/orion?authuser=1&project=poetic-genius-233804&tab=yaml 